### PR TITLE
Release 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ any Ruby object there is. Kiss good bye to complexity
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'Jsoning'
+gem 'jsoning'
 ```
 
 And then execute:
@@ -187,6 +187,18 @@ The syntax above will return ruby hash object:
  "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}}
 ```
 
+## Supporting custom data type
+
+JSON, by default support data type such as boolean, nil, string, and number. If you have class like
+`MyFancyString` and would tell Jsoning how to interpret and extract value from them, use this syntax:
+
+```ruby
+Jsoning.add_type MyFancyString, processor: { |fancy_string| fancy_string.get_string } 
+```
+
+Internally, it is how Jsoning convert date-like data type (`Date`, `DateTime`, `Time`, `ActiveSupport::TimeWithZone`) to
+ISO8601 which can be parsed by compliant JavaScript interpreter in the browser (or somewhere else).
+
 ## Changelog
 
 == Version 0.1.0
@@ -195,7 +207,12 @@ The syntax above will return ruby hash object:
 
 == Version 0.2.0
 
-2. Ability to turn object into a hash
+1. Ability to turn object into a hash
+
+== Version 0.3.0
+
+1. Allow user to specify how Jsoning would extract value from a custom data type
+2. Date, DateTime, Time, ActiveSupport::TimeWithZone now is by default parsed to ISO8601 format.
 
 ## License
 

--- a/lib/jsoning.rb
+++ b/lib/jsoning.rb
@@ -9,6 +9,8 @@ require "json"
 
 module Jsoning
   PROTOCOLS = {}
+  # if type is defined here, we will use it to extract its value for the key
+  TYPE_EXTENSIONS = {}
 
   module_function
 
@@ -41,6 +43,16 @@ module Jsoning
     protocol.generate(object, options)
   end
 
+  class << self
+    def add_type(klass, options = {})
+      processor = options[:processor]
+      raise Jsoning::Error, "Pass in processor that is a proc explaining how to extract the value" unless processor.is_a?(Proc)
+
+      TYPE_EXTENSIONS[klass.to_s] = processor
+      nil
+    end
+  end
+  
   def self.[](object) 
     protocol = protocol_for!(object.class)
     protocol.parse(object)

--- a/lib/jsoning.rb
+++ b/lib/jsoning.rb
@@ -50,6 +50,13 @@ module Jsoning
     return if @@type_extension_initialized
 
     begin
+      require "time"
+      ::Time
+      self.add_type Time, processor: proc { |time| time.iso8601 }
+    rescue
+    end
+
+    begin
       # try to define value extractor for ActiveSupport::TimeWithZone which is in common use
       # for AR model
       ::ActiveSupport::TimeWithZone

--- a/lib/jsoning/foundations/mapper.rb
+++ b/lib/jsoning/foundations/mapper.rb
@@ -50,23 +50,29 @@ class Jsoning::Mapper
     def deep_parse(object)
       parsed_data = nil
 
-      if object.is_a?(Array)
-        parsed_data = []
-        object.each do |each_obj|
-          parsed_data << deep_parse(each_obj)
-        end
-      elsif object.is_a?(Hash)
-        parsed_data = {}
-        object.each do |obj_key_name, obj_val|
-          parsed_data[obj_key_name] = deep_parse(obj_val)
-        end
-      elsif object.is_a?(Integer) || object.is_a?(Float) || object.is_a?(String) ||
-        object.is_a?(TrueClass) || object.is_a?(FalseClass) || object.is_a?(NilClass)
-        parsed_data = object
+      value_extractor = Jsoning::TYPE_EXTENSIONS[object.class.to_s]
+      if value_extractor # is defined
+        parsed_data = value_extractor.(object)
       else
-        protocol = Jsoning.protocol_for!(object.class)
-        parsed_data = protocol.parse(object)
+        if object.is_a?(Array)
+          parsed_data = []
+          object.each do |each_obj|
+            parsed_data << deep_parse(each_obj)
+          end
+        elsif object.is_a?(Hash)
+          parsed_data = {}
+          object.each do |obj_key_name, obj_val|
+            parsed_data[obj_key_name] = deep_parse(obj_val)
+          end
+        elsif object.is_a?(Integer) || object.is_a?(Float) || object.is_a?(String) ||
+          object.is_a?(TrueClass) || object.is_a?(FalseClass) || object.is_a?(NilClass)
+          parsed_data = object
+        else
+          protocol = Jsoning.protocol_for!(object.class)
+          parsed_data = protocol.parse(object)
+        end
       end
+
 
       parsed_data
     end

--- a/lib/jsoning/version.rb
+++ b/lib/jsoning/version.rb
@@ -1,3 +1,3 @@
 module Jsoning
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/jsonist_spec.rb
+++ b/spec/jsonist_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
+require "date"
 
 module My; end
 class My::User
   attr_accessor :name, :age, :gender
   attr_accessor :taken_degree
   attr_accessor :books
+  attr_accessor :created_at
 
   def initialize
     self.books = []
+    self.created_at = DateTime.parse("2015-11-01T14:41:09Z")
   end
 end
 class My::Book
@@ -98,6 +101,7 @@ describe Jsoning do
         key :gender, default: "male"
         key :books
         key :degree_detail, from: :taken_degree
+        key :registered_at, from: :created_at
       end
 
       Jsoning.for(My::Book) do
@@ -126,22 +130,22 @@ describe Jsoning do
 
     it "can generate json" do
       json = Jsoning(user)
-      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil})
+      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"})
 
       user.taken_degree = degree
 
       json = Jsoning(user)
-      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}})
+      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+00:00"})
     end
 
     it "can generate hash" do
       hash = Jsoning[user]
-      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil})
+      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"})
 
       user.taken_degree = degree
 
       hash = Jsoning[user]
-      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}})
+      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+00:00"})
     end
   end
 end


### PR DESCRIPTION
1. Allow user to specify how Jsoning would extract value from a custom data type
2. Types `Date`, `DateTime`, `Time`, `ActiveSupport::TimeWithZone` now are by default parsed to ISO8601 format.
