### PR TITLE
Hash interpret custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Calling: `Jsoning.parse(the_json_string, My::User)` will yield a Hash as follow:
 1. When passing a proc as default value, it will be executed to assign default value when value is nil.
 2. Parsing JSON string as hash by using `Jsoning.parse`
 
+== Version 0.5.0
+
+1. Bugfix: when Jsoning to Hash, if encountering data-like datatype, error is 
+   raised due to Jsoning does not know how to extract value from them. However, if the object
+   is converted to JSON string, everything is working as expected.
+
 ## License
 
 The gem is proudly available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/jsoning.rb
+++ b/lib/jsoning.rb
@@ -43,12 +43,13 @@ module Jsoning
 
   # generate the json document
   def generate(object, options = {})
-    initialize_type_extensions 
     protocol = protocol_for!(object.class)
     protocol.generate(object, options)
   end
 
   @@type_extension_initialized = false
+  # define value extractor/interpreter for commonly used ruby datatypes that are not
+  # part of standard types supported by JSON
   def initialize_type_extensions
     @@type_extension_initialized = true if !!@@type_extension_initialized
     return if @@type_extension_initialized
@@ -85,6 +86,7 @@ module Jsoning
   end
 
   def [](object) 
+    Jsoning.initialize_type_extensions 
     protocol = protocol_for!(object.class)
     protocol.retrieve_values_from(object)
   end
@@ -101,12 +103,14 @@ module Jsoning
     private
 
     def Jsoning(object, options = {})
+      Jsoning.initialize_type_extensions 
       Jsoning.generate(object, options)
     end
   end
 
   # parse the JSON String to Hash
   def parse(json_string, klass)
+    Jsoning.initialize_type_extensions 
     protocol = protocol_for!(klass)
     protocol.construct_hash_from(json_string)
   end

--- a/lib/jsoning/version.rb
+++ b/lib/jsoning/version.rb
@@ -1,3 +1,3 @@
 module Jsoning
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/jsonist_spec.rb
+++ b/spec/jsonist_spec.rb
@@ -34,6 +34,7 @@ end
 describe Jsoning do
   before(:each) do
     Jsoning.clear
+    Jsoning::TYPE_EXTENSIONS.clear
   end
 
   it 'has a version number' do
@@ -131,6 +132,14 @@ describe Jsoning do
         achievement = My::Achievement.new
         Jsoning[achievement]
       end.to raise_error(Jsoning::Error)
+    end
+
+    it "does not throw an error when interpreting DateTime" do
+      json_hash = Jsoning[user]
+      json_str = Jsoning(user)
+
+      expect(json_hash).to_not be_nil
+      expect(json_str).to_not be_nil
     end
 
     it "can generate json" do


### PR DESCRIPTION
Previously only converting to JSON string that date-like datatype can be properly extracted
