### PR TITLE
Release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Calling: `Jsoning.parse(the_json_string, My::User)` will yield a Hash as follow:
 1. When passing a proc as default value, it will be executed to assign default value when value is nil.
 2. Parsing JSON string as hash by using `Jsoning.parse`
 
+== Version 0.5.0
+
+1. Bugfix: when Jsoning to Hash, if encountering data-like datatype, error is 
+   raised due to Jsoning does not know how to extract value from them. However, if the object
+   is converted to JSON string, everything is working as expected.
+
 ## License
 
 The gem is proudly available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/jsoning.rb
+++ b/lib/jsoning.rb
@@ -43,12 +43,13 @@ module Jsoning
 
   # generate the json document
   def generate(object, options = {})
-    initialize_type_extensions 
     protocol = protocol_for!(object.class)
     protocol.generate(object, options)
   end
 
   @@type_extension_initialized = false
+  # define value extractor/interpreter for commonly used ruby datatypes that are not
+  # part of standard types supported by JSON
   def initialize_type_extensions
     @@type_extension_initialized = true if !!@@type_extension_initialized
     return if @@type_extension_initialized
@@ -85,6 +86,7 @@ module Jsoning
   end
 
   def [](object) 
+    Jsoning.initialize_type_extensions 
     protocol = protocol_for!(object.class)
     protocol.retrieve_values_from(object)
   end
@@ -101,12 +103,14 @@ module Jsoning
     private
 
     def Jsoning(object, options = {})
+      Jsoning.initialize_type_extensions 
       Jsoning.generate(object, options)
     end
   end
 
   # parse the JSON String to Hash
   def parse(json_string, klass)
+    Jsoning.initialize_type_extensions 
     protocol = protocol_for!(klass)
     protocol.construct_hash_from(json_string)
   end

--- a/lib/jsoning.rb
+++ b/lib/jsoning.rb
@@ -55,9 +55,8 @@ module Jsoning
     return if @@type_extension_initialized
 
     begin
-      require "time"
       ::Time
-      self.add_type Time, processor: proc { |time| time.iso8601 }
+      self.add_type Time, processor: proc { |time| time.strftime("%FT%T%z") }
     rescue
     end
 
@@ -65,21 +64,21 @@ module Jsoning
       # try to define value extractor for ActiveSupport::TimeWithZone which is in common use
       # for AR model
       ::ActiveSupport::TimeWithZone
-      self.add_type ActiveSupport::TimeWithZone, processor: proc { |time| time.send(:iso8601) }
+      self.add_type ActiveSupport::TimeWithZone, processor: proc { |time| time.strftime("%FT%T%z") }
     rescue 
       # nothing, don't add
     end
 
     begin
       ::DateTime
-      self.add_type DateTime, processor: proc { |date| date.send(:iso8601) }
+      self.add_type DateTime, processor: proc { |date| date.strftime("%FT%T%z") }
     rescue => e 
       # nothing, don't add
     end
 
     begin
       ::Date
-      self.add_type Date, processor: proc { |date| date.send(:iso8601) }
+      self.add_type Date, processor: proc { |date| date.strftime("%FT%T%z") }
     rescue 
       # nothing, don't add
     end

--- a/lib/jsoning/version.rb
+++ b/lib/jsoning/version.rb
@@ -1,3 +1,3 @@
 module Jsoning
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/jsonist_spec.rb
+++ b/spec/jsonist_spec.rb
@@ -34,6 +34,7 @@ end
 describe Jsoning do
   before(:each) do
     Jsoning.clear
+    Jsoning::TYPE_EXTENSIONS.clear
   end
 
   it 'has a version number' do
@@ -131,6 +132,14 @@ describe Jsoning do
         achievement = My::Achievement.new
         Jsoning[achievement]
       end.to raise_error(Jsoning::Error)
+    end
+
+    it "does not throw an error when interpreting DateTime" do
+      json_hash = Jsoning[user]
+      json_str = Jsoning(user)
+
+      expect(json_hash).to_not be_nil
+      expect(json_str).to_not be_nil
     end
 
     it "can generate json" do

--- a/spec/jsonist_spec.rb
+++ b/spec/jsonist_spec.rb
@@ -144,21 +144,48 @@ describe Jsoning do
 
     it "can generate json" do
       json = Jsoning(user)
-      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"})
+      expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"})
 
       user.taken_degree = degree
 
       json = Jsoning(user)
-      expected_hash = {"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+00:00"}
+      expected_hash = {"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+0000"}
       expect(JSON.parse(json)).to eq(expected_hash)
       expect(Jsoning.parse(json, My::User)).to eq(expected_hash)
+    end
+
+    context "when converting date-like datatype" do
+      it "can convert datetime" do
+        expect(user.created_at.class).to eq(DateTime)
+
+        expect(Jsoning[user]).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"})
+        expect(Jsoning(user)).to eq("{\"name\":\"Adam Baihaqi\",\"years_old\":21,\"gender\":\"male\",\"books\":[{\"name\":\"Quiet: The Power of Introvert\"},{\"name\":\"Harry Potter and the Half-Blood Prince\"}],\"degree_detail\":null,\"registered_at\":\"2015-11-01T14:41:09+0000\"}")
+      end
+
+      it "can convert time" do
+        user.created_at = user.created_at.to_time 
+        expect(user.created_at.class).to eq(Time)
+
+        json_hash = Jsoning[user]
+        expect(json_hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T21:41:09+0700"})
+        json = Jsoning(user)
+        expect(json).to eq("{\"name\":\"Adam Baihaqi\",\"years_old\":21,\"gender\":\"male\",\"books\":[{\"name\":\"Quiet: The Power of Introvert\"},{\"name\":\"Harry Potter and the Half-Blood Prince\"}],\"degree_detail\":null,\"registered_at\":\"2015-11-01T21:41:09+0700\"}")
+      end
+
+      it "can convert date" do
+        user.created_at = user.created_at.to_date
+        expect(user.created_at.class).to eq(Date)
+
+        expect(Jsoning[user]).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T00:00:00+0000"})
+        expect(Jsoning(user)).to eq("{\"name\":\"Adam Baihaqi\",\"years_old\":21,\"gender\":\"male\",\"books\":[{\"name\":\"Quiet: The Power of Introvert\"},{\"name\":\"Harry Potter and the Half-Blood Prince\"}],\"degree_detail\":null,\"registered_at\":\"2015-11-01T00:00:00+0000\"}")
+      end
     end
 
     context "when default value is a proc" do
       it "can generate json" do
         user.books = nil
         json = Jsoning(user)
-        expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"}) 
+        expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"}) 
       end
 
       it "can generate json when default value is full-blown script" do
@@ -177,19 +204,19 @@ describe Jsoning do
 
         user.books = nil
         json = Jsoning(user)
-        expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Mathematics 6A"}, {"name"=>"Physics A2"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"}) 
-        expect(Jsoning.parse(json, My::User)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Mathematics 6A"}, {"name"=>"Physics A2"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"})
+        expect(JSON.parse(json)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Mathematics 6A"}, {"name"=>"Physics A2"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"}) 
+        expect(Jsoning.parse(json, My::User)).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Mathematics 6A"}, {"name"=>"Physics A2"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"})
       end
     end
 
     it "can generate hash" do
       hash = Jsoning[user]
-      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+00:00"})
+      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>nil, "registered_at"=>"2015-11-01T14:41:09+0000"})
 
       user.taken_degree = degree
 
       hash = Jsoning[user]
-      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+00:00"})
+      expect(hash).to eq({"name"=>"Adam Baihaqi", "years_old"=>21, "gender"=>"male", "books"=>[{"name"=>"Quiet: The Power of Introvert"}, {"name"=>"Harry Potter and the Half-Blood Prince"}], "degree_detail"=>{"faculty"=>"School of IT", "degree"=>"B.Sc. (Hons) Computer Science"}, "registered_at"=>"2015-11-01T14:41:09+0000"})
     end
   end
 end


### PR DESCRIPTION
1. `Jsoning[object]` will correctly parse date-like datatype
2. Converting to ISO8601 uses `strftime`.
